### PR TITLE
use ujson instead of json for json encoding and decoding, don't pretty-print json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 click==5.1
 jsonschema==2.5.1
 requests==2.8.1
+ujson==1.33

--- a/scripts/utils.py
+++ b/scripts/utils.py
@@ -1,6 +1,6 @@
 
 import os
-import json
+import ujson
 import logging
 import tempfile
 import sys
@@ -37,12 +37,12 @@ def read_json(path):
     :returns: dict
     """
     with open(path, 'r') as jsonfile:
-        return json.loads(jsonfile.read())
+        return ujson.loads(jsonfile.read())
 
 
 def write_json(path, data):
     with open(path, 'w') as jsonfile:
-        jsonfile.write(json.dumps(data, indent=4, separators=(',', ': ')))
+        jsonfile.write(ujson.dumps(data, double_precision=5))
 
 
 def make_sure_path_exists(path):


### PR DESCRIPTION
Switch to ujson is for speed
not pretty-printing and limiting decimal places is to control output size of files. This reduces the size for generated/US/MT/deerelklion.geojson from 45mb to 13.
5 decimal places is ~1.1 meters, which is good enough.