### PR TITLE
add US/ND/fallturkey.json

### DIFF
--- a/sources/US/ND/fallturkey.json
+++ b/sources/US/ND/fallturkey.json
@@ -1,0 +1,14 @@
+{
+   "url": "http://www.nd.gov/gis/apps/DataDownload/?clipping=Full&coord=LL83&format=SHAPE&layers=NDGAMEFISH.UNIT_TURKEYFALL",
+   "species": [
+      "Fall Turkey"
+   ],
+   "attribution": "North Dakota Game and Fish Department",
+   "properties": {
+      "id": "OBJECTID_1",
+      "name": "UNIT_ID"
+   },
+   "country": "US",
+   "state": "ND",
+   "filetype": "shp"
+}

--- a/sources/US/ND/fallturkey.json
+++ b/sources/US/ND/fallturkey.json
@@ -1,5 +1,6 @@
 {
-   "url": "http://www.nd.gov/gis/apps/DataDownload/?clipping=Full&coord=LL83&format=SHAPE&layers=NDGAMEFISH.UNIT_TURKEYFALL",
+   "name" : "ND Fall Turkey Hunt Units",
+   "url": "https://data.openbounds.org.s3.amazonaws.com/USAHunting/manual-downloads/nd-fall-turkey.zip",
    "species": [
       "Fall Turkey"
    ],


### PR DESCRIPTION
ValueError: Support only 1 file in archive file /var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip when no explicit in-archive filename is specified
You could try one of the following :
  /vsizip//var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip/NDGISHubData
  /vsizip//var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip/NDGISHubData/NDGAMEFISH_UNIT_TURKEYFALL_polygon.dbf
  /vsizip//var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip/NDGISHubData/NDGAMEFISH_UNIT_TURKEYFALL_polygon.prj
  /vsizip//var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip/NDGISHubData/NDGAMEFISH_UNIT_TURKEYFALL_polygon.shp
  /vsizip//var/folders/gl/9wjcyk215xb4dns_6mc5jpj00000gp/T/tmpqtnvaYnd-fall-turkey.zip/NDGISHubData/NDGAMEFISH_UNIT_TURKEYFALL_polygon.shx
