### PR TITLE
CA Updates

### DIFF
--- a/sources/US/CA/bighornsheep.json
+++ b/sources/US/CA/bighornsheep.json
@@ -2,14 +2,16 @@
    "name": "CA Bighorn Sheep Hunt Zones",
    "url": "ftp://ftp.dfg.ca.gov/BDB/GIS/BIOS/Public_Datasets/700_799/ds784.zip",
    "species": [
-      "big horn sheep"
+      "bighorn sheep"
    ],
    "attribution": "California Department of Fish and Wildlife",
    "properties": {
       "id": "Zone",
-      "name": "Hunt_Name"
+      "name": "Zone"
    },
    "country": "US",
    "state": "CA",
-   "filetype": "shp"
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for bighorn hunt"
 }

--- a/sources/US/CA/deerhuntunits.json
+++ b/sources/US/CA/deerhuntunits.json
@@ -11,5 +11,7 @@
    },
    "country": "US",
    "state": "CA",
-   "filetype": "shp"
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for deer hunt"
 }

--- a/sources/US/CA/elk.json
+++ b/sources/US/CA/elk.json
@@ -1,15 +1,17 @@
 {
    "name": "CA Elk Hunt Zones",
-   "url": "ftp://ftp.dfg.ca.gov/BDB/GIS/BIOS/Public_Datasets/700_799/ds786.zip",
+   "url": "https://data.openbounds.org.s3.amazonaws.com/USAHunting/manual-downloads/ca-elk-zones.zip",
    "species": [
       "elk"
    ],
    "attribution": "California Department of Fish and Wildlife",
    "properties": {
-      "id": "Hunt_Name",
-      "name": "Hunt_Name"
+      "id": "Zone",
+      "name": "Zone"
    },
    "country": "US",
    "state": "CA",
-   "filetype": "shp"
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for elk hunt & add zone numbers from http://www.eregulations.com/wp-content/uploads/2017/05/elk-map.pdf"
 }

--- a/sources/US/CA/grouse.json
+++ b/sources/US/CA/grouse.json
@@ -1,0 +1,17 @@
+{
+   "name": "CA Sooty (Blue) & Ruffed Grouse Hunt Zone",
+   "url": "ftp://ftp.dfg.ca.gov/BDB/GIS/BIOS/Public_Datasets/1300_1399/ds1341.zip",
+   "species": [
+      "grouse"
+   ],
+   "attribution": "California Department of Fish and Wildlife",
+   "properties": {
+      "id": "Species",
+      "name": "Species"
+   },
+   "country": "US",
+   "state": "CA",
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for grouse hunt"
+}

--- a/sources/US/CA/nonlead-ammunition-area.json
+++ b/sources/US/CA/nonlead-ammunition-area.json
@@ -6,8 +6,8 @@
    ],
    "attribution": "California Department of Fish and Wildlife",
    "properties": {
-      "id": "ZONE_LTR",
-      "name": "Zone_Name"
+      "id": "Name",
+      "name": "Name"
    },
    "country": "US",
    "state": "CA",

--- a/sources/US/CA/nonlead-ammunition-area.json
+++ b/sources/US/CA/nonlead-ammunition-area.json
@@ -1,0 +1,17 @@
+{
+   "name": "CA Nonlead Ammunition Area",
+   "url": "https://data.openbounds.org.s3.amazonaws.com/USAHunting/manual-downloads/ca-nonlead-area.zip",
+   "species": [
+      "all"
+   ],
+   "attribution": "California Department of Fish and Wildlife",
+   "properties": {
+      "id": "ZONE_LTR",
+      "name": "Zone_Name"
+   },
+   "country": "US",
+   "state": "CA",
+   "filetype": "shp",
+    "year": "2017",
+    "source": "KML download https://www.wildlife.ca.gov/Hunting/Deer#54774-zones--hunts & Condor layer"
+}

--- a/sources/US/CA/pronghorn.json
+++ b/sources/US/CA/pronghorn.json
@@ -1,5 +1,5 @@
 {
-   "name": "CA Pronghorn Hunt Zones",
+   "name": "CA Pronghorn Antelope Hunt Zones",
    "url": "ftp://ftp.dfg.ca.gov/BDB/GIS/BIOS/Public_Datasets/700_799/ds787.zip",
    "species": [
       "pronghorn"
@@ -7,9 +7,11 @@
    "attribution": "California Department of Fish and Wildlife",
    "properties": {
       "id": "Zone",
-      "name": "Hunt_Name"
+      "name": "Zone"
    },
    "country": "US",
    "state": "CA",
-   "filetype": "shp"
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for pronghorn hunt"
 }

--- a/sources/US/CA/public-hunting-areas.json
+++ b/sources/US/CA/public-hunting-areas.json
@@ -1,0 +1,18 @@
+{
+   "name": "CA Wildlife Areas & Reserves",
+   "url": "https://data.openbounds.org.s3.amazonaws.com/USAHunting/manual-downloads/ca-public-access-lands.zip",
+   "filenameInZip": "CA-PublicAccessLands.shp",
+   "species": [
+      "all"
+   ],
+   "attribution": "California Department of Fish and Wildlife",
+   "properties": {
+      "id": "OBJECTID",
+      "name": "PROP_NAME"
+   },
+   "country": "US",
+   "state": "CA",
+   "filetype": "shp",
+   "year": "2017",
+   "source": "https://map.dfg.ca.gov/lands/ & CDFW Public Access Lands layer with fishing access polygons removed"
+}

--- a/sources/US/CA/quail.json
+++ b/sources/US/CA/quail.json
@@ -1,0 +1,17 @@
+{
+   "name": "CA Quail Hunt Zones",
+   "url": "ftp://ftp.dfg.ca.gov/BDB/GIS/BIOS/Public_Datasets/1300_1399/ds1342.zip",
+   "species": [
+      "quail"
+   ],
+   "attribution": "California Department of Fish and Wildlife",
+   "properties": {
+      "id": "ZoneDes",
+      "name": "ZoneDes"
+   },
+   "country": "US",
+   "state": "CA",
+   "filetype": "shp",
+   "year": "2017",
+   "source": "http://portal.gis.ca.gov/geoportal/catalog/search/search.page & search for quail hunt"
+}


### PR DESCRIPTION
- updated bighorn sheep, deer, elk, & pronghorn jsons to include year and source fields
- corrected elk json to match CDFW regulation map and labels
- added jsons for grouse, quail, public hunting areas (wildlife areas, public access, & reservers), and the California condor nonlead ammunition area
